### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ MIT
 * `git clone git@github.com:ibm-frontend/gatsby-carbon-starter.git`
 * `cd gatsby-carbon-starter`
 * `npm install`
-* `gatsby develop`
+* `npm run develop`
 * visit http://localhost:8000
 
 ## Setup via Gatsby CLI


### PR DESCRIPTION
Use local gatsby for non-global no-cli setup.

If they're not installing via the cli, they prob don't have gatsby globally so use the npm script which uses the local version.